### PR TITLE
auth/db/api: JWT roles + swagger auth + booking+ids cleanup

### DIFF
--- a/app/apis/decorators.py
+++ b/app/apis/decorators.py
@@ -3,8 +3,21 @@ from flask_jwt_extended import verify_jwt_in_request, get_jwt
 from flask_restx import abort
 from flask_jwt_extended.exceptions import NoAuthorizationError, InvalidHeaderError
 
-def require_roles(allowed_roles):
-    """decorator to authorize users based on their role claim in the JWT. must be called with a list of roles, e.g., @require_roles(["member"])"""
+def require_roles(*allowed_roles):
+    """Authorize users based on their JWT role claim.
+
+    Supports both call styles:
+    - @require_roles(["member", "guest"])
+    - @require_roles("member", "guest")
+    """
+    if len(allowed_roles) == 1 and isinstance(allowed_roles[0], (list, tuple, set)):
+        normalized_roles = set(allowed_roles[0])
+    else:
+        normalized_roles = set(allowed_roles)
+
+    if not normalized_roles:
+        raise ValueError("require_roles() requires at least one role")
+
     def wrapper(fn):
         @wraps(fn)
         def decorator(*args, **kwargs):
@@ -19,8 +32,8 @@ def require_roles(allowed_roles):
             user_role = claims.get("role")
             
             #then heck if the user's role is in the allowed list
-            if user_role not in allowed_roles:
-                abort(403, f"role '{user_role}' has insufficient permissions. require to be: {allowed_roles}")
+            if user_role not in normalized_roles:
+                abort(403, f"role '{user_role}' has insufficient permissions. require to be: {sorted(normalized_roles)}")
             
             # 4. If authorized, proceed to the endpoint
             return fn(*args, **kwargs)

--- a/app/apis/fitness_class.py
+++ b/app/apis/fitness_class.py
@@ -65,7 +65,6 @@ class ClassListResource(Resource):
         api.model(MSG, {MSG: fields.List(fields.Nested(class_model))}),
     )
     @api.response(HTTPStatus.BAD_REQUEST, "Invalid payload")
-    @require_roles("guest", "member")
     def get(self):
         """
         SEE CLASS LIST: allowed for all users

--- a/app/db/bookings.py
+++ b/app/db/bookings.py
@@ -39,7 +39,7 @@ def build_booking_document(
 	user_id: str,
 	user_name: str,
 	user_email: str,
-	phone: str,
+	phone: str | None,
 	role: str,
 	*,
 	booking_id: str | None = None,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -26,7 +26,7 @@ def runner(app):
 def trainer_headers(app):
     with app.app_context():
         token = create_access_token(
-            identity="trainer-test-user",
-            additional_claims={"role": "trainer"},
+            identity="trainer@example.com",
+            additional_claims={"role": "trainer", "user_id": "trainer-test-user"},
         )
     return {"Authorization": f"Bearer {token}"}


### PR DESCRIPTION
## Updates & Improvements

### Local Development

* Fixed local environment dependencies (`flask-restx`, `mongomock`) so `make run_local_server` works properly.

---

### Authentication & Registration

* Made phone optional during registration.
* Default role set to `member`.
* Added user DB **build + create** helpers.
* Refactored registration to use the DB layer.
* Issue JWT `access_token` on:
  * Register
  * Login
* Use email as JWT identity.
* Include `role` and `user_id` as JWT claims.
* Simplified login to email-only (Swagger model and backend aligned).

---

### Authorization & Security

* Added role-based `require_roles` decorator:

  * Returns `401` / `403` on authentication errors.
  * Supports both list and varargs styles.
* Enabled Swagger UI Bearer token “Authorize” support.
* Protected endpoints:
  * Class creation → `trainer` / `admin`
  * Booking → `member`
---

### Database Improvements

* Generate sequential class IDs (`class_001`, `class_002`, ...) via Mongo counter.
* Prevent duplicate registration by email or phone (returns `409`).
* Updated booking flow:

  * Uses JWT email identity.
  * No `user_id` required.
  * No phone required.

---

### Testing

* Updated tests to send JWT headers.
* Fixed JWT subject type to `string`.
