### PR TITLE
Ci workflow/tianze

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI Pipeline
+
+#Run on every push and PR to the main branch
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    # These environment variables are required by config.py
+    # MOCK_DB must be "true" to use mongomock instead of a real DB
+    env:
+      MONGO_URI: "mongodb://localhost:27017/testdb"
+      DB_NAME: "testdb"
+      MOCK_DB: "true"
+      DEBUG: "true"
+      JWT_SECRET_KEY: "dummy-secret-key-for-ci-testing"
+
+    steps:
+    - name: Check out the repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+        cache: "pip" 
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements-dev.txt
+
+    - name: Run tests and check coverage
+      run: |
+        pytest -vv --verbose --cov-config=.coveragerc --cov=app tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI Pipeline
 #Run on every push and PR to the main branch
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main" , "CI_Workflow/Tianze"]
   pull_request:
     branches: [ "main" ]
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![CI Pipeline](https://github.com/cs-uh-2012-spring26/cs-uh-2012-software-engineering-group_b/actions/workflows/ci.yml/badge.svg)
+
 # Fitness Class Management System API
 
 This repo contains a Flask-RESTX API foundation for the Sprint 1 Fitness Class Management System.


### PR DESCRIPTION
Set up CI pipeline and add status badge. Created a GitHub Actions workflow (ci.yml) to automatically run tests on pushes and PRs to the main branch. Configured dummy environment variables to satisfy config.py requirements. Added the CI build status badge to the top of README.md