### PR TITLE
feat(email): migrate reminders to SendGrid SDK and document CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,28 @@
 
 # Fitness Class Management System API
 
-This repo contains a Flask-RESTX API foundation for the Sprint 1 Fitness Class Management System.
+This repo contains a Flask-RESTX API foundation for the Sprint 2 Fitness Class Management System.
+
+## Recent Updates
+
+### 1) CI implementation (GitHub Actions)
+
+- A CI workflow is configured and published via the repository badge at the top of this README.
+- On each push/PR, the pipeline validates the project by installing dependencies and running automated checks.
+- This gives quick feedback on regressions and keeps the default branch stable.
+
+### 2) Email reminder sending with SendGrid SDK
+
+- Reminder delivery now uses the official SendGrid Python SDK (`sendgrid`) for outbound emails.
+- The reminder service builds class-based reminder content and sends one email per recipient with deterministic recipient normalization.
+- Required environment variable: `SENDGRID_API_KEY`.
+- Optional environment variable: `SENDGRID_FROM_EMAIL` (defaults to `noreply@coachly.dev` when not provided).
+
+### 3) Unit testing updates
+
+- Added/updated unit tests for the email reminder service flow in `tests/unit/test_email_reminders_service.py`.
+- Tests cover message building, recipient normalization, API key validation, successful sends, rejected SendGrid statuses, and wrapped transport errors.
+- Test doubles now mock SendGrid SDK client behavior for deterministic service-level tests.
 
 Current scaffolded features:
 
@@ -25,6 +46,9 @@ to install MongoDB locally. Select the right link for your operating system.
 
 ```text
 .
+├── .github/
+│   └── workflows/
+│       └── ci.yml                # CI pipeline for automated checks on push/PR
 ├── app/
 │   ├── __init__.py                # Flask app factory and namespace registration
 │   ├── config.py                  # Environment-driven app config
@@ -41,6 +65,9 @@ to install MongoDB locally. Select the right link for your operating system.
 │       ├── fitness_classes.py     # Fitness class collection/fields
 │       ├── users.py               # User collection/role field definitions
 │       └── utils.py               # Serialization helpers
+│   └── services/
+│       ├── __init__.py
+│       └── email_reminders.py     # SendGrid-based reminder email orchestration
 ├── docs/
 ├── reports/                       # Requirements/spec artifacts
 ├── tests/
@@ -50,7 +77,9 @@ to install MongoDB locally. Select the right link for your operating system.
 │   │   ├── conftest.py            # Pytest fixtures
 │   │   ├── test_auth_api.py       # Auth endpoint tests
 │   │   ├── test_booking_api.py    # Booking endpoint tests
-│   │   └── test_fitness_api.py    # Fitness class endpoint tests
+│   │   ├── test_email_reminders_service.py  # Email reminder service unit tests
+│   │   ├── test_fitness_api.py    # Fitness class endpoint tests
+│   │   └── test_general.py        # General API sanity and behavior tests
 │   └── utils.py                   # Testing utilities
 ├── makefile
 ├── requirements.txt
@@ -69,6 +98,11 @@ This Flask web app uses:
 (see [flask specific testing instructions on pytest][pytest-flask]
 for more info specific to testing Flask applications)
 - [mongomock][mongomock] for mocking the mongodb during unit testing
+- [SendGrid Python SDK][sendgrid-sdk] for reminder email delivery
+- [requests][requests-docs] for HTTP client integrations/utilities
+- [pytest-mock][pytest-mock] for clean mocking patterns in unit tests
+- [pytest-cov][pytest-cov] for coverage reporting
+- [GitHub Actions][gha] for CI automation
 
 [flask-restx]: https://flask-restx.readthedocs.io/en/latest/quickstart.html
 [flask-restx-scaling]: https://flask-restx.readthedocs.io/en/latest/scaling.html
@@ -77,6 +111,11 @@ for more info specific to testing Flask applications)
 [pytest]: https://docs.pytest.org/en/stable/
 [pytest-flask]: https://flask.palletsprojects.com/en/stable/testing/
 [mongomock]: https://docs.mongoengine.org/guide/mongomock.html
+[sendgrid-sdk]: https://github.com/sendgrid/sendgrid-python
+[requests-docs]: https://requests.readthedocs.io/en/latest/
+[pytest-mock]: https://pytest-mock.readthedocs.io/
+[pytest-cov]: https://pytest-cov.readthedocs.io/
+[gha]: https://docs.github.com/actions
 
 ## Running Locally
 
@@ -103,6 +142,10 @@ You can use `ctrl-c` to stop the server.
 Run `make tests` to execute the test suite and see the coverage report
 in your terminal. You can also see a visual report by viewing
 [/htmlcov/index.html](/htmlcov/index.html) in your browser.
+
+For targeted unit testing during development, you can run specific files such as:
+
+- `pytest tests/unit/test_email_reminders_service.py -q`
 
 ## Current API Endpoints
 

--- a/app/services/email_reminders.py
+++ b/app/services/email_reminders.py
@@ -1,7 +1,7 @@
-import json
 from os import environ
-from urllib.error import HTTPError, URLError
-from urllib.request import Request, urlopen
+
+from sendgrid import SendGridAPIClient  # pyright: ignore[reportMissingImports]
+from sendgrid.helpers.mail import Content, From, Mail, To  # pyright: ignore[reportMissingImports]
 
 from app.db.fitness_classes import DATETIME, TITLE, TRAINER_NAME
 
@@ -44,28 +44,18 @@ def _resolve_sender_email(sender_email: str | None) -> str:
 
 
 def _sendgrid_send_email(api_key: str, sender_email: str, recipient_email: str, subject: str, body: str) -> None:
-    """Send one email via SendGrid Mail Send API."""
-    payload = {
-        "personalizations": [{"to": [{"email": recipient_email}]}],
-        "from": {"email": sender_email},
-        "subject": subject,
-        "content": [{"type": "text/plain", "value": body}],
-    }
-
-    request = Request(
-        "https://api.sendgrid.com/v3/mail/send",
-        data=json.dumps(payload).encode("utf-8"),
-        headers={
-            "Authorization": f"Bearer {api_key}",
-            "Content-Type": "application/json",
-        },
-        method="POST",
+    """Send one email via SendGrid SDK."""
+    message = Mail(
+        from_email=From(sender_email),
+        to_emails=To(recipient_email),
+        subject=subject,
+        plain_text_content=Content("text/plain", body),
     )
 
-    with urlopen(request, timeout=20) as response:  # nosec B310 - controlled SendGrid API URL
-        status_code = getattr(response, "status", response.getcode())
-        if status_code not in (200, 202):
-            raise RuntimeError(f"SendGrid rejected email with status {status_code}")
+    response = SendGridAPIClient(api_key).send(message)
+    status_code = getattr(response, "status_code", None)
+    if status_code not in (200, 202):
+        raise RuntimeError(f"SendGrid rejected email with status {status_code}")
 
 
 def send_class_reminders(
@@ -92,7 +82,7 @@ def send_class_reminders(
             _sendgrid_send_email(api_key, sender, recipient, subject, body)
             sent_count += 1
             sent_recipients.append(recipient)
-    except (HTTPError, URLError) as exc:
+    except Exception as exc:
         raise RuntimeError(f"Unable to send reminder email(s): {exc}") from exc
 
     return {"sent_count": sent_count, "recipients": sent_recipients}

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ Flask-APScheduler==1.13.1
 boto3==1.39.8
 flask_cors==6.0.1
 python-dateutil==2.9.0
+sendgrid==6.12.5

--- a/tests/unit/test_email_reminders_service.py
+++ b/tests/unit/test_email_reminders_service.py
@@ -13,19 +13,10 @@ from app.services import email_reminders as svc
 
 
 class _FakeResponse:
-    """Small context-manager-compatible fake for urlopen responses."""
+    """Small fake for SendGrid SDK responses."""
 
     def __init__(self, status: int):
-        self.status = status
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        return False
-
-    def getcode(self):
-        return self.status
+        self.status_code = status
 
 
 def test_build_reminder_message_uses_class_fields():
@@ -66,8 +57,10 @@ def test_normalize_recipients_deduplicates_and_sorts():
 
 
 def test_sendgrid_send_email_success(mocker):
-    """SendGrid helper should call urlopen once for successful send."""
-    mocked_urlopen = mocker.patch("app.services.email_reminders.urlopen", return_value=_FakeResponse(202))
+    """SendGrid helper should call SDK client once for successful send."""
+    mocked_client_cls = mocker.patch("app.services.email_reminders.SendGridAPIClient")
+    mocked_client = mocked_client_cls.return_value
+    mocked_client.send.return_value = _FakeResponse(202)
 
     svc._sendgrid_send_email(
         api_key="SG.fake",
@@ -77,12 +70,15 @@ def test_sendgrid_send_email_success(mocker):
         body="Body",
     )
 
-    mocked_urlopen.assert_called_once()
+    mocked_client_cls.assert_called_once_with("SG.fake")
+    mocked_client.send.assert_called_once()
 
 
 def test_sendgrid_send_email_rejected_status(mocker):
     """Non-accepted HTTP status from SendGrid should raise runtime error."""
-    mocker.patch("app.services.email_reminders.urlopen", return_value=_FakeResponse(500))
+    mocked_client_cls = mocker.patch("app.services.email_reminders.SendGridAPIClient")
+    mocked_client = mocked_client_cls.return_value
+    mocked_client.send.return_value = _FakeResponse(500)
 
     with pytest.raises(RuntimeError, match="SendGrid rejected email with status 500"):
         svc._sendgrid_send_email(


### PR DESCRIPTION
- Replaced manual urllib SendGrid calls with official SendGrid SDK client

- Updated email reminder unit tests to mock SDK responses

- Added sendgrid dependency to requirements

- Expanded README with CI implementation and SendGrid reminder feature notes